### PR TITLE
solved an issue with Anova.lm when test.statistic is provided in the call

### DIFF
--- a/R/Anova.R
+++ b/R/Anova.R
@@ -116,7 +116,7 @@ Anova.lm <- function(mod, error, type=c("II","III", 2, 3),
   }
   if (any(is.na(coef(mod))) && singular.ok){
     message("Note: model has aliased coefficients\n      sums of squares computed by model comparison")
-    result <- Anova(lm2glm(mod), type=type, singular.ok=TRUE, test.statistic="F", ...)
+    result <- Anova(lm2glm(mod), type=type, singular.ok=TRUE, ...)
     heading <- attributes(result)$heading
     if (type == "2") type <- "II"
     if (type == "3") type <- "III"
@@ -125,10 +125,10 @@ Anova.lm <- function(mod, error, type=c("II","III", 2, 3),
   }
   if (white.adjust != "FALSE"){
     if (white.adjust == "TRUE") white.adjust <- "hc3" 
-    return(Anova.default(mod, type=type, vcov.=hccm(mod, type=white.adjust), test.statistic="F", 
+    return(Anova.default(mod, type=type, vcov.=hccm(mod, type=white.adjust), 
                          singular.ok=singular.ok, ...))
   }
-  else if (!is.null(vcov.)) return(Anova.default(mod, type=type, vcov.=vcov., test.statistic="F", 
+  else if (!is.null(vcov.)) return(Anova.default(mod, type=type, vcov.=vcov., 
                                                  singular.ok=singular.ok, ...))
   switch(type,
          II=Anova.II.lm(mod, error, singular.ok=singular.ok, ...),


### PR DESCRIPTION
In cases where test.statistic was provided to Anova when used on a lm class model,  test.statistic is provided twice to Anova, causing an error to be thrown